### PR TITLE
TandaPay events related types can now use aliases as type parameters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Hex } from "viem";
 import {
   AliasToRawEventNameMapping,
   RawEventNameToAliasMapping,
-} from "tandapay_manager/read/tandapay_event_aliases";
+} from "tandapay_manager/read/types";
 
 // private keys we can use for testing purposes here
 export const PRIVATE_KEYS: Hex[] = [

--- a/src/tandapay_manager/read/tandapay_events.ts
+++ b/src/tandapay_manager/read/tandapay_events.ts
@@ -4,7 +4,7 @@ import {
   TandaPayEventAlias,
   tandaPayEventAliasesToAbiEvents,
   tandaPayEventAliasToAbiEvent,
-} from "./tandapay_event_aliases";
+} from "./types";
 import {
   AbiEvent,
   Address,

--- a/test/integration/claim.test.ts
+++ b/test/integration/claim.test.ts
@@ -9,7 +9,7 @@ import {
   TandaPayEventAlias,
   TandaPayLog,
   toTandaPayLogs,
-} from "tandapay_manager/read/tandapay_event_aliases";
+} from "tandapay_manager/read/types";
 
 let anvil: ChildProcess;
 let suite: TandaPayTestSuite;
@@ -79,10 +79,9 @@ describe("testing claims, defectors, etc.", () => {
       logs.find((l) => l.alias === "claimWhitelisted") ??
       fail("no claimWhitelisted log");
     // narrow the types
-    // TODO: improve this to allow for aliases instead of raw type names
-    const submitted = l1 as TandaPayLog<"ClaimSubmitted">;
-    const whitelisted = l2 as TandaPayLog<"ClaimWhiteListed">;
-    // ensure that the whitelisted claim and submitted claim are the same
+    const submitted = l1 as TandaPayLog<"claimSubmitted">
+    const whitelisted = l2 as TandaPayLog<"claimWhitelisted">
+    // ensure they're the same
     expect(submitted.args.claimId).toBe(whitelisted.args.cId);
   }, 30000);
 });


### PR DESCRIPTION
aliases now work in type parameters for TandaPayLogs, and there is also now a type TandaPayEventAliasArgs which returns the arguments associated with a tandapay event based on its alias. Added a new type predicate `isValidEventAliasArgs` so that we can test the validity of args given just an alias now as well. Renamed tandapay_event_aliases.ts to types.ts, as the start of a larger reorganization effort