### PR TITLE
14 auto reorg

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,13 @@
   "dependencies": {
     "pnpm": "^10.3.0",
     "viem": "^2.22.4"
+  },
+  "pnpm": {
+    "ignoredBuiltDependencies": [
+      "esbuild"
+    ],
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }

--- a/src/auto_reorg.ts
+++ b/src/auto_reorg.ts
@@ -106,7 +106,7 @@ function assignToEmptyGroups(newSubgroups: Address[][], emptySubgroups: number[]
   return solution;
 }
 
-export function ar(params: ArParams): Map<number, Address[]> {
+export function autoReorg(params: ArParams): Map<number, Address[]> {
   // removes anyone in needsAssigned from the subgroup members lists,
   // and also removes any excess members in any subgroups and adds them
   // to needsAssigned
@@ -170,7 +170,7 @@ export function ar(params: ArParams): Map<number, Address[]> {
         }
       }
     }
-    return ar({subgroups, needsAssigned});
+    return autoReorg({subgroups, needsAssigned});
   }
   return solution;
 }

--- a/src/auto_reorg.ts
+++ b/src/auto_reorg.ts
@@ -1,39 +1,77 @@
 import { Address } from "viem";
- 
+
+// constants
 const MIN_SUBGROUP_SIZE = 4 as const;
 const MAX_SUBGROUP_SIZE = 7 as const;
 
-interface ArParams {
-  subgroups: Map<number, Address[]>;
-  needsAssigned: Address[];
+// types
+type SubgroupId = number;
+type Members = Address[];
+type Subgroups = Map<SubgroupId, Members>;
+type SizeToSubgroupId = Map<number, SubgroupId[]>;
+type SubroutineParameters = AutoReorgParameters & { sizeSortedGroups: SizeToSubgroupId };
+
+// Error messages
+const ErrorMessages = {
+  UNDEFINED_MEMBER: "Auto reorg error: undefined member encountered",
+  MIN_SIZE_VIOLATION: "Cannot make new groups when needsAssigned is smaller than the minimum subgroup size",
+  UNDEFINED_ASSIGNMENT: "Got undefined when making new subgroups"
+} as const;
+
+
+export interface AutoReorgParameters {
+  /** mapping between subgroup IDs and the subgroup members lists */
+  subgroups: Map<SubgroupId, Members>;
+  /** a list of all members that need to be assigned to new subgroups to be valid */
+  needsAssigned: Members;
 }
 
-function filterSubgroups(params: ArParams): ArParams {
-  let {subgroups, needsAssigned} = params;
-  // we want to filter subgroups to ensure they don't have the
-  // paid-invalid members still listed in them, and to remove
-  // excess members from any subgroups that are too large, marking
-  // those excess members as needing reassigned
-  const filteredSubgorups = new Map<number, Address[]>();
-  for (let [id, members] of subgroups) {
-    const newMembers = members.filter(m => !needsAssigned.includes(m));
-    while (newMembers.length > MAX_SUBGROUP_SIZE)  {
-      const m = newMembers.pop();
-      if (m === undefined)
-        throw new Error("auto reorg error: undefined member popped from too large subgroup?")
+/**
+ * Accepts AutoReorgParameters and filters the subgroups so that we don't have any that are
+ * too big or too small -- only valid and empty ones, with members needing to be assigned to
+ * subgroups being in the `needsAssigned` array
+ * @returns its parameters but with the subgroups filtered and the needsAssigned array including
+ * members that were excess in subgroups that were too large
+ */
+function filterSubgroups({subgroups, needsAssigned}: AutoReorgParameters): AutoReorgParameters {
+  const filteredSubgroups = new Map<SubgroupId, Members>();
+  const newNeedsAssigned: Members = [...needsAssigned];
 
-      needsAssigned.push(m); 
-    }
-    filteredSubgorups.set(id, newMembers);
-  }
-  params.subgroups = filteredSubgorups;
-  return params;
-}
-
-function sortSubgroupsBySize(subgroups: Map<number, Address[]>): Map<number, number[]> {
-  // (size, ids[])
-  const sizeSortedGroups = new Map<number, number[]>();
   for (const [id, members] of subgroups) {
+    // we want to ensure that only valid members are in the subgroup
+    const validMembers = members.filter(m => !needsAssigned.includes(m));
+    const finalMembers = [...validMembers];
+
+    // ensure that the subgroup is not too large
+    while (finalMembers.length > MAX_SUBGROUP_SIZE) {
+      const member = finalMembers.pop();
+      if (member === undefined)
+        throw new Error(ErrorMessages.UNDEFINED_MEMBER);
+
+      newNeedsAssigned.push(member);
+    }
+
+    // finally, after those operations have been performed, add it to the
+    // filtered subgroups result. It's possible that the subgroup hasn't been modified
+    filteredSubgroups.set(id, finalMembers);
+  }
+
+  // return fixed parameters
+  return {
+    subgroups: filteredSubgroups,
+    needsAssigned: newNeedsAssigned,
+  }
+}
+
+/** groups subgroups by their member count */
+function sortSubgroupsBySize(subgroups: Subgroups): SizeToSubgroupId {
+  // map to store the result. key will be the size of the subgroup,
+  // value will be all of the subgroup IDs that are of that size
+  const sizeSortedGroups = new Map<number, SubgroupId[]>();
+  for (const [id, members] of subgroups) {
+    // get the size. If we have already seen subgroups of this
+    // size, append it to the array. Otherwise, initialize a new
+    // array with this being the first one
     const size = members.length;
     if (sizeSortedGroups.has(size)) {
       sizeSortedGroups.get(size)!.push(id);
@@ -44,133 +82,260 @@ function sortSubgroupsBySize(subgroups: Map<number, Address[]>): Map<number, num
   return sizeSortedGroups;
 }
 
-function getValidCapacity(sortedSubgroups: Map<number, number[]>) {
-  let capacity = 0;
+/** 
+ * Returns the total number of slots available across all existing valid
+ * subgroups, for reorging members to be assigned into
+ */
+function getValidCapacity(sortedSubgroups: SizeToSubgroupId) {
+  // count the total slots available
+  let slotsAvailable = 0;
+
+  // find subgroups that are at least the minimum size, and
+  // less than the maximum size
   for (let i = MIN_SUBGROUP_SIZE; i < MAX_SUBGROUP_SIZE; i++) {
-    const cap = MAX_SUBGROUP_SIZE - i;
+    // this is the capacity of subgroups this size
+    const capacity = MAX_SUBGROUP_SIZE - i;
+    // this is how many of them we have
     const numGroupsThisSize = sortedSubgroups.get(i)?.length;
+    // this can be undefined if there were no subgroups of this size
     if (numGroupsThisSize === undefined)
       continue;
 
-    capacity += (numGroupsThisSize * cap);
+    // otherwise, the slots available across all subgroups of this size will be
+    // the capacity multiplied by the number of subgroups
+    slotsAvailable += (numGroupsThisSize * capacity);
   }
-  return capacity;
+  return slotsAvailable;
 }
 
+/** 
+ * Accepts a list of members that need to be divided into new valid subgroups, and
+ * returns a 2D array of addresses, where each subarray represents a list of members
+ * that can make up a valid subgroup. Every subarray is guaranteed to be at least
+ * MIN_SUBGROUP_SIZE and to not exceed MAX_SUBGROUP_SIZE
+ */
 function makeNewGroups(needsAssigned: Address[]) {
+  // if we don't have enough members to make new subgroups out of,
+  // then we can't make any valid subgroups. throw an error.
   if (needsAssigned.length < MIN_SUBGROUP_SIZE)
-    throw new Error("cannot make new groups when needsAssigned is smaller than the minimum subgroup size!!");
+    throw new Error(ErrorMessages.MIN_SIZE_VIOLATION);
 
-  const newSubgroups: Address[][] = [];    
-  let curSubgroup: Address[] = [];
+  // we'll store a list of members-lists, where each members-list
+  // will represent a separate subgroup
+  const newSubgroups: Members[] = [];
+
+  // this is the current members-list we're building
+  let curSubgroup: Members = [];
+  // while we have members needing assigned
   while (needsAssigned.length > 0) {
+    // pop them off
     const m = needsAssigned.pop();
     if (m === undefined)
-      throw new Error("auto reorg error: undefined member popped from needsAssigned?");
+      throw new Error(ErrorMessages.UNDEFINED_ASSIGNMENT);
     
+    // add them to the current group
     curSubgroup.push(m);
+    // if it reaches te min size, add this to the list of new
+    // subgroups we're making and start building the next subgroup
     if (curSubgroup.length === MIN_SUBGROUP_SIZE) {
       newSubgroups.push([...curSubgroup]);
       curSubgroup = new Array<Address>();
     }
   }
 
+  // if there were any stragglers, that means the last group we
+  // were building did not have enough members to make a complete subgroup.
+  // Given that `(MIN_SUBGROUP_SIZE) + (MIN_SUBGROUP_SIZE-1) === MAX_SUBGROUP_SIZE`,
+  // that means it can never make a subgroup too large to simply add these
+  // stragglers to one of the subgroups we just made. So, one of them will be larger
+  // than the minimum size, but that's fine.
   if (curSubgroup.length > 0)
     newSubgroups[0].push(...curSubgroup);
 
   return newSubgroups;
 }
 
-function assignToEmptyGroups(newSubgroups: Address[][], emptySubgroups: number[], maxSubgroupId: number) {
-  const solution = new Map<number, Address[]>();
-  while (emptySubgroups.length > 0 && newSubgroups.length > 0) {
-    const id = emptySubgroups.pop();
-    const members = newSubgroups.pop();
+/**
+ * This is used for case 1, when we have enough members needing reassigned that we can make
+ * new subgroups, then we can just do that. For the subgroup IDs, first it will reuse existing
+ * empty subgroup IDs, then it will go on to making new subgroup IDs that may not exist yet
+ */
+function assignToEmptyGroups(params: SubroutineParameters) {
+  const {subgroups, needsAssigned, sizeSortedGroups} = params;
+  // divide all of the members needing assigned into separate groups
+  const memberGroupings = makeNewGroups(needsAssigned);
+  // get an array of all empty subgroup IDs
+  const emptySubgroupIds = sizeSortedGroups.get(0) ?? [];
+  // this is used so that we know what IDs to use for any new
+  // subgroups we create
+  const maxSubgroupId = subgroups.size;
+
+  // first exhaust the empty subgroups. While there are empty subgroups
+  // we can use and we still have member groupings we can put in them
+  while (emptySubgroupIds.length > 0 && memberGroupings.length > 0) {
+    // get a subgroup id to use and a group of members to place in it
+    const id = emptySubgroupIds.pop();
+    const members = memberGroupings.pop();
+    // if either of those is invalid, throw an error
     if (!id || !members)
-      throw new Error("got undefined when making new subgroups, popped (id, members) pair and expected a defined result");
+      throw new Error(ErrorMessages.UNDEFINED_ASSIGNMENT);
 
-    solution.set(id, members);
+    // modify the subgroups with this part of the solution
+    subgroups.set(id, members);
   }
 
-  if (newSubgroups.length > 0) {
-    let newSubgroupId = maxSubgroupId + 1;
-    while (newSubgroups.length > 0) {
-      const members = newSubgroups.pop();
-      if (!members)
-        throw new Error("got undefined when making new subgroups. popped member and expected a defined result");
+  // we'll start at this ID, as no subgroup has this ID yet
+  let newSubgroupId = maxSubgroupId + 1;
+  // so long as we still have member groupings, we'll start
+  // making new subgroups to place them in
+  while (memberGroupings.length > 0) {
+    // get a member grouping to make a new subgroup for
+    const members = memberGroupings.pop();
+    // it should never be undefined but if it is throw an error
+    if (!members)
+      throw new Error(ErrorMessages.UNDEFINED_ASSIGNMENT);
 
-      solution.set(newSubgroupId, members);
-      newSubgroupId += 1;
-    } 
-  }
-  return solution;
+    // create new subgroup for them as part of the solution
+    subgroups.set(newSubgroupId, members);
+    newSubgroupId += 1;
+  } 
+
+  // return modified params; subgroups will have been modified
+  // with the members needing assigned being placed in their new
+  // valid subgroups
+  return {subgroups, needsAssigned, sizeSortedGroups};
 }
 
-export function autoReorg(params: ArParams): Map<number, Address[]> {
-  // removes anyone in needsAssigned from the subgroup members lists,
-  // and also removes any excess members in any subgroups and adds them
-  // to needsAssigned
-  params = filterSubgroups(params);
-  const {subgroups, needsAssigned} = params;
+/**
+ * Case 2. This happens when we don't have enough members needing reassignment
+ * to put them all together in their own subgroup(s), but we do have enough capacity
+ * within existing valid subgroups to add them to.
+ */
+function distributeToExistingSubgroups(params: SubroutineParameters) {
+  let {subgroups, needsAssigned, sizeSortedGroups} = params;
 
-  // sorts the subgroups into (size, [ids...]) pairs
-  let sizeSortedGroups = sortSubgroupsBySize(subgroups);
-  const validCapacity = getValidCapacity(sizeSortedGroups);
+  // go through every valid subgroup size that is not max capacity
+  for (let i = MIN_SUBGROUP_SIZE; i < MAX_SUBGROUP_SIZE; i += 1) {
+    // get all of the subgroup ids at this size
+    const groups = sizeSortedGroups.get(i);
 
-  // stores the address and what new subgroup they should be assigned to
-  const solution = new Map<number, Address[]>(subgroups);
+    // if there are none, just skip it
+    if (!groups || groups.length === 0)
+      continue;
+    // if nobody else needs assigned, we can exit
+    if (needsAssigned.length === 0)
+      break;
 
-  // make new subgroups
-  if (needsAssigned.length >= MIN_SUBGROUP_SIZE) {
-    const newSubgroups = makeNewGroups(needsAssigned);
-    const emptySubgroups = sizeSortedGroups.get(0) ?? [];
-    const maxSubgroupId = subgroups.size;
-    const assignments = assignToEmptyGroups(newSubgroups, emptySubgroups, maxSubgroupId);
-    for (const [id, members] of assignments)
-      solution.set(id, members);
-
-  // assign to existing subgroups
-  } else if (validCapacity >= needsAssigned.length) {
-    for (let i = MIN_SUBGROUP_SIZE; i < MAX_SUBGROUP_SIZE; i += 1) {
-      const groups = sizeSortedGroups.get(i);
-      if (!groups || groups.length === 0)
-        continue;
+    // otherwise, go through each subgroup of this size
+    for (const id of groups) {
+      // if nobody else needs assigned, we can exit
       if (needsAssigned.length === 0)
         break;
 
-      for (const id of groups) {
-        if (needsAssigned.length === 0)
-          break;
-
-        const memberToAssign = needsAssigned.pop()!;
-        solution.get(id)!.push(memberToAssign);
-      }
-      sizeSortedGroups = sortSubgroupsBySize(solution);
+      // assign a member to this subgroup
+      const memberToAssign = needsAssigned.pop()!;
+      subgroups.get(id)!.push(memberToAssign);
     }
-    
-  // in this case, we don't have enough people needing reassigned to make new subgroups,
+
+    // redo the sorting because the subgroup sizes have changed
+    sizeSortedGroups = sortSubgroupsBySize(subgroups);
+  }
+
+  // subgroups will have been modified with the new assignments
+  // being reflected
+  return {subgroups, needsAssigned, sizeSortedGroups};
+}
+
+/**
+ * Case 3; this happens when we don't have enough space in existing valid subgroups for
+ * for members to be assigned to, and we also don't have enough members needing assignment
+ * for them to have a subgroup of their own. In this case, we will have to remove members
+ * from an existing valid subgroup so that there are enough needing assignment that they
+ * can make a valid subgroup of their own
+ */
+function rebalanceGroupsForNewFormation(params: SubroutineParameters) {
+  let {subgroups, needsAssigned, sizeSortedGroups} = params;
+
+  // we'll start with the biggest subgroups and work our way down through
+  // each valid subgroup that is big enough that removing a member won't
+  // cause it to become invalid
+  for (let i = MAX_SUBGROUP_SIZE; i > MIN_SUBGROUP_SIZE; i--) {
+    // get all of the groups of this size
+    const groups = sizeSortedGroups.get(i);
+    // if there are none, just continue to the next smallest size
+    if (!groups || groups.length === 0)
+      continue;
+
+    // go through each group
+    for (const id of groups) {
+      // get the members in that group
+      const members = subgroups.get(id)!;
+      // so long as we have enough members to pop out of this group and we don't have
+      // enough needing assignment to make a valid subgroup yet, then remove members and
+      // mark them as needing assignment
+      while (members.length > MIN_SUBGROUP_SIZE && needsAssigned.length < MIN_SUBGROUP_SIZE) {
+        const removedMember = members.pop();
+        // should never happen but if it does throw an error
+        if (!removedMember)
+          throw new Error(ErrorMessages.UNDEFINED_MEMBER);
+
+        // mark as needs assignment
+        needsAssigned.push(removedMember);
+      }
+    }
+  }
+
+  // since subgroup sizes have changed, redo sorting
+  sizeSortedGroups = sortSubgroupsBySize(subgroups);
+  // subgroups has been modified to reflect the new changes
+  return {subgroups, needsAssigned, sizeSortedGroups};
+}
+
+/** internal auto-reorg method that is the entry point for the actual algoritm */
+function ar(params: SubroutineParameters): Map<SubgroupId, Members> {
+  // total number of slots in existing valid subgroups that we could potentially
+  // assign reorging members into
+  const validCapacity = getValidCapacity(params.sizeSortedGroups);
+
+  // case 1: make new subgroups
+  if (params.needsAssigned.length >= MIN_SUBGROUP_SIZE) {
+    params = assignToEmptyGroups(params);
+  // case 2: assign to existing subgroups
+  } else if (validCapacity >= params.needsAssigned.length) {
+    params = distributeToExistingSubgroups(params);
+  // case 3: we don't have enough people needing reassigned to make new subgroups,
   // but we also don't have enough capacity in existing valid subgroups to assign them to,
   // so we have to remove people from a valid group (without causing that group to become
   // smaller than the minimum size) and mark them for reassignment so we can potentially
   // make a new subgroup with them + the members already needing reassigned.
   } else {
-    for (let i = MAX_SUBGROUP_SIZE; i > MIN_SUBGROUP_SIZE; i--) {
-      const groups = sizeSortedGroups.get(i);
-      if (!groups || groups.length === 0)
-        continue;
-
-      for (const id of groups) {
-        const members = subgroups.get(id)!;
-        while (members.length > MIN_SUBGROUP_SIZE && needsAssigned.length < MIN_SUBGROUP_SIZE) {
-          const removedMember = members.pop();
-          if (!removedMember)
-            throw new Error("auto reorg error: removed a member and expected a defined result");
-
-          needsAssigned.push(removedMember);
-        }
-      }
-    }
-    return autoReorg({subgroups, needsAssigned});
+    params = rebalanceGroupsForNewFormation(params);
+    return ar(params);
   }
-  return solution;
+
+  return params.subgroups;
+}
+
+/**
+ * Reorganizes subgroups such that every member has a subgroup, and every subgroup is valid.
+ * @param params Accepts a k-v mapping of `(subgroupId, memberAddresses)` for existing subgroups
+ * as well as a list of members that are needing assigned.
+ * @returns a mapping of `(subgroupId, memberAddresses)` k-v pairs
+ * that represents all of the members divided into subgroups in such a way that every subgroup
+ * is valid and we performed a minimal amount of reassignments to get there.
+ */
+export function autoReorg(params: AutoReorgParameters): Map<number, Address[]> {
+  // removes anyone in needsAssigned from the subgroup members lists,
+  // and also removes any excess members in any subgroups and adds them
+  // to needsAssigned
+  const filteredParams = filterSubgroups(params);
+
+  // sorts the subgroups into (size, [ids...]) pairs
+  const sizeSortedGroups = sortSubgroupsBySize(filteredParams.subgroups);
+
+  // return the solutoin
+  return ar({
+    ...filteredParams,
+    sizeSortedGroups,
+  });
 }

--- a/src/auto_reorg.ts
+++ b/src/auto_reorg.ts
@@ -9,6 +9,7 @@ export type AutoReorgParameters = {
   paidInvalidMembers: Address[],
 }
 
+//TODO: complete
 export function autoReorg(params: AutoReorgParameters) {
   const {subgroupInfoMap, paidInvalidMembers} = params;
 

--- a/src/auto_reorg.ts
+++ b/src/auto_reorg.ts
@@ -1,110 +1,7 @@
-import { error } from "console";
-import { SubgroupInfo } from "types";
 import { Address } from "viem";
  
 const MIN_SUBGROUP_SIZE = 4 as const;
 const MAX_SUBGROUP_SIZE = 7 as const;
-
-export type AutoReorgParameters = {
-  subgroupInfoMap: Map<bigint, SubgroupInfo>,
-  paidInvalidMembers: Address[],
-}
-
-//TODO: complete
-export function autoReorg(params: AutoReorgParameters) {
-  const {subgroupInfoMap, paidInvalidMembers} = params;
-
-  // categorize each subgroup
-  const emptyIds: bigint[] = [];
-  const invalidIds: bigint[] = [];
-  const validNotFullIds: bigint[] = [];
-  const fullIds: bigint[] = [];
-
-  // keep track of some other variables that will be useful
-  let paidInvalidCount = paidInvalidMembers.length; let existingValidCapacity = 0;
-
-  // store the solution
-  const solution = new Map<bigint, Address[]>();
-
-  for (const [id, info] of subgroupInfoMap) {
-    if (info.members.length === 0) {
-      // if there are no members, subgroup is empty
-      emptyIds.push(id);
-    } else if (info.members.length > 0 && info.members.length < MIN_SUBGROUP_SIZE) {
-      // if there are members but the subgroup is too small to be valid,
-      // then the members in it are invalid.
-      invalidIds.push(id);
-    } else if (info.members.length >= MIN_SUBGROUP_SIZE && info.members.length < MAX_SUBGROUP_SIZE) {
-      // subgroups that are valid but not full
-      validNotFullIds.push(id);
-      existingValidCapacity += MAX_SUBGROUP_SIZE - info.members.length;
-    } else {
-      // finally, full subgroups. we'll pop from these if we need members to make new valid subgroups
-      fullIds.push(id);
-    }
-  }
-
-  // if the paid invalid count is enough to make a valid subgroup
-  // using only the existing paid invalid members, we'll do that
-  const newSubgroups: Address[][] = [];
-  if (paidInvalidCount >= MIN_SUBGROUP_SIZE) {
-    // we want to divide them into groups of 4, but if the number of paid-invalid members
-    // isn't perfectly divisible by 4, then we'll have an odd subgroup of 5/6/7 to ensure
-    // that they are all successfully assigned
-    let curSubgroup: Address[] = [];
-    // we'll iterate while we have paid-invalid members
-    while (paidInvalidMembers.length > 0) {
-      // get this paid-invalid member
-      const addr = paidInvalidMembers.pop()!;
-      // assign them to the subgroup
-      curSubgroup.push(addr);
-      // once it reaches 4 members, add it to the newSubgroups list and reset
-      if (curSubgroup.length === 4) {
-        newSubgroups.push(curSubgroup);
-        curSubgroup = [];
-      }
-    }
-
-    // finally, if we had a last subgroup that did not reach 4 members, it
-    // wouldn't have been added. These are our "odd" members, we can just add
-    // them to one of the groups of 4 we already created
-    if (curSubgroup.length > 0)
-      newSubgroups[0].push(...curSubgroup);
-
-    //! for debugging
-    if (paidInvalidMembers.length > 0)
-      throw new Error("this should never appear. paidInvalidMembers length > 0 after autoReorg. (0)");
-  // otherwise, if there is enough space in the existing valid subgroups, then we
-  // will reassign these paid-invalid members into those subgroups
-  } else if (paidInvalidCount <= existingValidCapacity) {
-    // iterate through the IDs of each valid subgroup
-    for (const id of validNotFullIds) {
-      // we'll start off our new subgroup with the existing members in this one
-      let curSubgroup: Address[] = subgroupInfoMap.get(id)!.members.slice();
-      // so long as there is capacity in this subgroup and we still have
-      // paid-invalid members who need to be reorged, we'll add them to this subgroup:
-      while (paidInvalidMembers.length > 0 && curSubgroup.length < MAX_SUBGROUP_SIZE) {
-        const addr = paidInvalidMembers.pop()!;
-        curSubgroup.push(addr);
-      }
-      // and now, we have either ran out of capacity or assigned all of the paid-invalid
-      // members, so it's time to add this subgroup to the newSubgroups array
-      newSubgroups.push(curSubgroup);
-    }
-  
-    //! for debugging
-    if (paidInvalidMembers.length > 0)
-      throw new Error("this should never appear. paidInvalidMembers length > 0 after autoReorg. (1)");
-  // finally, if neither of those two things worked, that means we need to pop a valid member
-  // out of their group so that they can make a new valid subgroup with the paid-invalid members.
-  // we'll prioritize subgroups of size 7, and if that doesn't work, we'll work our way down to 6 and 5
-  } else {
-    // first lets calculate how many need reassigned
-    let totalNeedingReassigned = paidInvalidMembers.length; 
-  }
-
-  return solution;
-}
 
 interface ArParams {
   subgroups: Map<number, Address[]>;
@@ -238,8 +135,13 @@ export function ar(params: ArParams): Map<number, Address[]> {
       const groups = sizeSortedGroups.get(i);
       if (!groups || groups.length === 0)
         continue;
+      if (needsAssigned.length === 0)
+        break;
 
       for (const id of groups) {
+        if (needsAssigned.length === 0)
+          break;
+
         const memberToAssign = needsAssigned.pop()!;
         solution.get(id)!.push(memberToAssign);
       }

--- a/test/unit/auto_reorg.test.ts
+++ b/test/unit/auto_reorg.test.ts
@@ -60,7 +60,6 @@ function doTest(subgroupSizes: number[]) {
 }
 
 describe("auto reorg", () => {
-
   it("subgroup sizes: 3, 4, 4", () => {
     doTest([3,4,4]);
   });
@@ -74,6 +73,7 @@ describe("auto reorg", () => {
   });
 
   it("random tests? let's see if they work", () => {
+    let totalTests = 0;
     for (let i = 0; i < 5000; i++) {
       const numSubgroups = 3 + Math.ceil(Math.random() * 20);
       const subgroupSizes: number[] = [];
@@ -85,6 +85,8 @@ describe("auto reorg", () => {
         continue;
 
       doTest(subgroupSizes);
+      totalTests += 1;
     }
+    console.log(totalTests);
   });
 });

--- a/test/unit/auto_reorg.test.ts
+++ b/test/unit/auto_reorg.test.ts
@@ -72,6 +72,14 @@ describe("auto reorg", () => {
     doTest([2,2,7]);
   });
 
+  it("all valid subgroups", () => {
+    doTest([4,4,4]);
+  })
+
+  it("valid subgroups and one too large", () => {
+    doTest([4,4,8]);
+  })
+
   it("random tests? let's see if they work", () => {
     let totalTests = 0;
     for (let i = 0; i < 5000; i++) {
@@ -87,6 +95,5 @@ describe("auto reorg", () => {
       doTest(subgroupSizes);
       totalTests += 1;
     }
-    console.log(totalTests);
   });
 });

--- a/test/unit/auto_reorg.test.ts
+++ b/test/unit/auto_reorg.test.ts
@@ -1,4 +1,4 @@
-import { ar } from "auto_reorg";
+import { autoReorg } from "auto_reorg";
 import { Address } from "viem";
 
 
@@ -49,7 +49,7 @@ describe("auto reorg", () => {
   it("subgroup sizes: 3, 4, 4", () => {
     const subgroups = makeSubgroups([3, 4, 4]);
     const needsAssigned = subgroups.get(1)!;
-    const sol = ar({subgroups,needsAssigned});
+    const sol = autoReorg({subgroups,needsAssigned});
     expect(validateSubgroups(sol)).toBe(true);
     //console.log(sol);
   });
@@ -57,7 +57,7 @@ describe("auto reorg", () => {
   it("subgroup sizes: 1, 7, 7", () => {
     const subgroups = makeSubgroups([1,7,7]);
     const needsAssigned = subgroups.get(1)!;
-    const sol = ar ({subgroups,needsAssigned});
+    const sol = autoReorg ({subgroups,needsAssigned});
     expect(validateSubgroups(sol)).toBe(true);
     //console.log(sol);
   });
@@ -67,7 +67,7 @@ describe("auto reorg", () => {
     const needsAssigned = subgroups.get(1)!;
     needsAssigned.push(...subgroups.get(2)!);
     console.log(subgroups);
-    const sol = ar ({subgroups,needsAssigned});
+    const sol = autoReorg ({subgroups,needsAssigned});
     console.log(sol);
     expect(validateSubgroups(sol)).toBe(true);
   });

--- a/test/unit/auto_reorg.test.ts
+++ b/test/unit/auto_reorg.test.ts
@@ -1,0 +1,74 @@
+import { ar } from "auto_reorg";
+import { Address } from "viem";
+
+
+function validateSubgroups(subgroups: Map<number, Address[]>, countEmpty: boolean = false): boolean {
+  const uniqueMembers = new Set<Address>();
+  for (const [id, members] of subgroups) {
+    if (members.length > 0 && members.length < 4)
+      return false;
+    if (members.length > 7)
+      return false;
+    if (countEmpty && members.length === 0)
+      return false;
+
+    for (const m of members) {
+      if (uniqueMembers.has(m.toLowerCase() as Address))
+        return false;
+      else
+        uniqueMembers.add(m.toLowerCase() as Address);
+    }
+  }
+
+  return true;
+}
+
+function generateAddress(): Address {
+  return `0x${[...Array(40)]
+    .map(() => Math.floor(Math.random() * 16).toString(16))
+    .join('')}` as Address;
+}
+
+function makeSubgroup(size: number) {
+  const addresses: Address[] = []
+  for (let i = 0; i < size; i++)
+    addresses.push(generateAddress());
+
+  return addresses;
+}
+
+function makeSubgroups(sizes: number[]) {
+  const subgroups = new Map<number, Address[]>();
+  for (const [index, size] of sizes.entries()) {
+    subgroups.set(index+1, makeSubgroup(size));
+  }
+  return subgroups;
+}
+
+describe("auto reorg", () => {
+  it("subgroup sizes: 3, 4, 4", () => {
+    const subgroups = makeSubgroups([3, 4, 4]);
+    const needsAssigned = subgroups.get(1)!;
+    const sol = ar({subgroups,needsAssigned});
+    expect(validateSubgroups(sol)).toBe(true);
+    //console.log(sol);
+  });
+
+  it("subgroup sizes: 1, 7, 7", () => {
+    const subgroups = makeSubgroups([1,7,7]);
+    const needsAssigned = subgroups.get(1)!;
+    const sol = ar ({subgroups,needsAssigned});
+    expect(validateSubgroups(sol)).toBe(true);
+    //console.log(sol);
+  });
+
+  it("subgroup sizes: 2, 2, 7", () => {
+    const subgroups = makeSubgroups([2,2,7]);
+    const needsAssigned = subgroups.get(1)!;
+    needsAssigned.push(...subgroups.get(2)!);
+    console.log(subgroups);
+    const sol = ar ({subgroups,needsAssigned});
+    console.log(sol);
+    expect(validateSubgroups(sol)).toBe(true);
+  });
+});


### PR DESCRIPTION
closes #14 

Implemented auto reorg. Accepts subgroups and reorganizes them such that all members have a subgroup and all subgroups are valid. Does this while making a relatively minimal amount of changes to existing valid subgroups